### PR TITLE
Fix OVS test suite failing

### DIFF
--- a/.github/workflows/dpkg-build.yml
+++ b/.github/workflows/dpkg-build.yml
@@ -278,6 +278,7 @@ jobs:
       - stage3-build
     container:
       image: ${{ matrix.target }}
+      options: --init
     strategy:
       matrix:
         package:


### PR DESCRIPTION
Use the docker option `--init ` to make the test suite run successfully when building Open vSwitch.

When creating docker containers, GitHub actions sets the initial command to `tail -f /dev/null`. For some reason some OVS unit tests fail when `tail -f [FILE]` is run as PID 1. GitHub actions doesn’t let you change the initial command, so using `--init` is a way I found to change what process is PID 1. This fixes the issue by running the command `docker-init` as PID 1 instead of `tail -f /dev/null`.

See [docker docs - Specify an init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process)