### PR TITLE
Fix dh_strip error when building OVS on Debian Buster

### DIFF
--- a/.github/workflows/dpkg-build.yml
+++ b/.github/workflows/dpkg-build.yml
@@ -104,6 +104,12 @@ jobs:
           curl -fLO https://deb.debian.org/debian/pool/main/m/meson/meson_0.49.2-1_all.deb
           dpkg -i meson_0.49.2-1_all.deb
         if: matrix.target == 'ubuntu:bionic'
+      - name: Backport debhelper on buster
+        run: |
+          echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+          apt-get update
+          apt-get install -y debhelper/buster-backports
+        if: matrix.target == 'debian:buster'
       - name: Build package
         run: |
           cd "./${{ matrix.package }}/"
@@ -176,6 +182,12 @@ jobs:
           curl -fLO https://deb.debian.org/debian/pool/main/m/meson/meson_0.49.2-1_all.deb
           dpkg -i meson_0.49.2-1_all.deb
         if: matrix.target == 'ubuntu:bionic'
+      - name: Backport debhelper on buster
+        run: |
+          echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+          apt-get update
+          apt-get install -y debhelper/buster-backports
+        if: matrix.target == 'debian:buster'
       - name: Add openvswitch apt repo
         run: |
           curl -1sLf 'https://dl.cloudsmith.io/public/wand/openvswitch/cfg/setup/bash.deb.sh' | bash
@@ -249,6 +261,12 @@ jobs:
           curl -fLO https://deb.debian.org/debian/pool/main/m/meson/meson_0.49.2-1_all.deb
           dpkg -i meson_0.49.2-1_all.deb
         if: matrix.target == 'ubuntu:bionic'
+      - name: Backport debhelper on buster
+        run: |
+          echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+          apt-get update
+          apt-get install -y debhelper/buster-backports
+        if: matrix.target == 'debian:buster'
       - name: Add openvswitch apt repo
         run: |
           curl -1sLf 'https://dl.cloudsmith.io/public/wand/openvswitch/cfg/setup/bash.deb.sh' | bash
@@ -321,6 +339,12 @@ jobs:
           curl -fLO https://deb.debian.org/debian/pool/main/m/meson/meson_0.49.2-1_all.deb
           dpkg -i meson_0.49.2-1_all.deb
         if: matrix.target == 'ubuntu:bionic'
+      - name: Backport debhelper on buster
+        run: |
+          echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+          apt-get update
+          apt-get install -y debhelper/buster-backports
+        if: matrix.target == 'debian:buster'
       - name: Add openvswitch apt repo
         run: |
           curl -1sLf 'https://dl.cloudsmith.io/public/wand/openvswitch/cfg/setup/bash.deb.sh' | bash


### PR DESCRIPTION
Fix the OVS build error on buster by backporting debhelper.

The debhelper version available on buster is 12.1.1. When building OVS on buster, while debhelper 12.1.1 is installed, this error occurs:

```
...
dh_strip --dbg-package=openvswitch-dbg
cp: 'debian/openvswitch-dbg/usr/lib/debug/.dwz/x86_64-linux-gnu' and 'debian/openvswitch-dbg/usr/lib/debug/.dwz/x86_64-linux-gnu' are the same file
dh_strip: cp --reflink=auto -a debian/openvswitch-dbg/usr/lib/debug/.dwz/x86_64-linux-gnu debian/openvswitch-dbg/usr/lib/debug/.dwz returned exit code 1
make[1]: *** [debian/rules:252: override_dh_strip] Error 1
make[1]: Leaving directory '/__w/openvswitch/openvswitch/openvswitch/src'
make: *** [debian/rules:9: binary] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
##[error]Process completed with exit code 2.
```

This is caused by a bug where dh_strip doesn’t avoid copying `.../debug/.dwz/` to itself, which is fixed by this [change](https://github.com/Debian/debhelper/commit/75639d0f64005ca72d84b8378ce24fe3ea1818ce) made in a later version of debhelper, version 12.6. Version 13 is available via buster-backports and when installed OVS builds successfully.