### PR TITLE
Fix rdma-core failing to install on Ubuntu Xenial

### DIFF
--- a/rdma-core/boot.sh
+++ b/rdma-core/boot.sh
@@ -3,3 +3,8 @@
 set -euo pipefail
 
 git clone --recurse-submodules https://github.com/linux-rdma/rdma-core -b v32.0 src
+
+if [ "${BUILD_TARGET}" == "ubuntu:xenial" ]; then
+    sed -zi 's/install(FILES "mlx4.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}\/modprobe.d\/")\n//' src/providers/mlx4/CMakeLists.txt
+    sed -zi 's/etc\/modprobe.d\/mlx4.conf\n//' src/debian/rdma-core.install
+fi


### PR DESCRIPTION
Fix rdma-core package conflict error with kmod on xenial.

```
dpkg: error processing archive /var/cache/apt/archives/rdma-core_32.0-1_amd64.deb (--unpack):
 trying to overwrite '/etc/modprobe.d/mlx4.conf', which is also in package kmod 22-1ubuntu5.2
```

On xenial etc/modprobe.d/mlx4.conf is already provided by kmod. This causes a conflict, which is resolved by building the rdma-core package without the file on xenial.